### PR TITLE
avoid error when mp3 has thumbnail image

### DIFF
--- a/src/completeAkashicAudio.ts
+++ b/src/completeAkashicAudio.ts
@@ -102,6 +102,7 @@ function convert(param: ConvertParameterObject): Promise<void> {
 	}
 
 	const ffmpegCmd = ffmpeg(sourcePath);
+	ffmpegCmd.addOption("-map a");
 	if (ffmpegPath)
 		ffmpegCmd.setFfmpegPath(ffmpegPath);
 


### PR DESCRIPTION
## このpull requestが解決する内容

サムネイルのメタデータを持つmp3ファイルを入力に渡した際に、エラーが出る問題を修正します。
<!-- Pull Requestの変更内容の概要を書いてください -->
## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

